### PR TITLE
feat: Add manual Android build workflow

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -1,0 +1,24 @@
+name: Manual Android Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin' # Popular distribution
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that allows for manual triggering of an Android build.

The workflow (`.github/workflows/manual_build.yml`) includes the following:
- Manual trigger using `workflow_dispatch`.
- Checkout of the repository code.
- Setup of JDK 17.
- Execution of the Gradle build command (`./gradlew build`).

This enables you to initiate a build process directly from the GitHub Actions tab.