### PR TITLE
Fix: Add missing navigation graph to resolve NavController error

### DIFF
--- a/WebradioApp/app/src/main/res/navigation/nav_graph.xml
+++ b/WebradioApp/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/emptyFragment">
+
+    <fragment
+        android:id="@+id/emptyFragment"
+        android:name="androidx.fragment.app.Fragment"
+        android:label="Empty" />
+</navigation>


### PR DESCRIPTION
The application was crashing due to a missing navigation graph referenced in `activity_main.xml`.

This commit introduces a minimal `nav_graph.xml` file in `app/src/main/res/navigation/` and ensures `activity_main.xml` correctly points to it. This resolves the "navigation destination com.example.webradioapp:id/nav_graph is unknown to this NavController" error.

The new `nav_graph.xml` includes an empty fragment as a starting destination, which is a common practice for initial setup or diagnostics.