### PR TITLE
Fix: Correct parameters in getTags call in SearchFragment

### DIFF
--- a/WebradioApp/app/src/main/java/com/example/webradioapp/fragments/SearchFragment.kt
+++ b/WebradioApp/app/src/main/java/com/example/webradioapp/fragments/SearchFragment.kt
@@ -123,7 +123,7 @@ class SearchFragment : Fragment() {
             }
 
             try {
-                val tagsResponse = apiService.getTags(limit = 200, hideBroken = true, order = "stationcount", reverse = true) // Fetch more relevant tags
+                val tagsResponse = apiService.getTags(limit = 200) // Fetch more relevant tags
                 if (tagsResponse.isSuccessful) {
                     tagsList = tagsResponse.body() ?: emptyList()
                     val displayTags: MutableList<String> = mutableListOf(anyCategoryString)


### PR DESCRIPTION
The `apiService.getTags()` call in `SearchFragment.kt` was using `hideBroken`, `order`, and `reverse` parameters that are not defined in the `RadioBrowserApiService.getTags()` function signature. This caused compilation errors.

This commit removes these unsupported parameters from the `getTags` call, aligning it with the actual API definition. The `limit` parameter is retained.

This also likely resolves a subsequent "Not enough information to infer type variable R" error related to an ArrayAdapter, which was probably a cascading effect of the initial compilation failures. The tags will now be fetched without specific server-side ordering by station count or filtering for broken tags via this specific API call, and will be sorted alphabetically by name in the UI as per the existing client-side code.