### PR TITLE
Fix: Correct GitHub Actions build failures due to KSP errors

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -69,7 +69,7 @@ jobs:
       continue-on-error: true
 
     - name: Build APK (debug)
-      run: ./gradlew :WebradioApp:app:assembleDebug --stacktrace --info --no-daemon --refresh-dependencies > build_output.log 2>&1
+      run: ./gradlew clean :WebradioApp:app:assembleDebug --stacktrace --info --no-daemon --refresh-dependencies > build_output.log 2>&1
 
     - name: Upload build log
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The primary issue causing build failures in your GitHub Actions workflow was related to Kotlin Symbol Processing (KSP) errors for the Room database. Specifically, KSP reported "no such table: stations" and related issues, despite the Room entity and database configurations appearing correct in your source code.

This commit addresses the problem by:
1. Modifying your GitHub Actions workflow (`.github/workflows/manual_build.yml`) to include the `clean` task in the Gradle build command. This ensures a completely fresh build, which should resolve issues with potentially stale KSP-generated files that might have been causing the errors.

Analysis of your codebase also revealed the following, which are noted as recommendations for future cleanup:
- The root `app/` directory appears to be unused by the Gradle build (which only includes `:WebradioApp:app`) and could be removed to avoid confusion.
- The Java version used for compiling your project (Java 17) could be aligned with the JDK version used in the GitHub Actions workflow (JDK 21) for better consistency.

Your initial report suggested problems with "dependency links," but my investigation showed that dependency resolution was succeeding, and the failures were occurring later, during code generation and compilation phases due to KSP and Room setup interpretation.